### PR TITLE
Remove logo referencing BSD3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
-[![License](https://img.shields.io/badge/License-BSD3-lightgrey.svg)](https://opensource.org/licenses/BSD-3-Clause)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # Triton Inference Server FIL Backend
 


### PR DESCRIPTION
Triton-FIL is Apache 2 licensed; remove stray reference to BSD3